### PR TITLE
Removes the -IncludePrerelease option from the Install-Package command

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,13 +16,13 @@ changes to source control and share with your team, then you also want the Nuget
 To install from Nuget, for the C# version:
 
 {% highlight powershell %}
-Install-Package CodeCracker.CSharp -IncludePrerelease
+Install-Package CodeCracker.CSharp
 {% endhighlight %}
 
 Or for the Visual Basic version:
 
 {% highlight powershell %}
-Install-Package CodeCracker.VisualBasic -IncludePrerelease
+Install-Package CodeCracker.VisualBasic
 {% endhighlight %}
 
 Or use the Package Manager in Visual Studio.


### PR DESCRIPTION
Since the final version was released, set the IncludePrerelease option is not necessary any more.
